### PR TITLE
Arreglar test de elementos-pares

### DIFF
--- a/ejercicios-algoritmos/sesion-1/elementos-pares/index.test.ts
+++ b/ejercicios-algoritmos/sesion-1/elementos-pares/index.test.ts
@@ -6,6 +6,6 @@ describe("filtrarPares", () => {
   it("deberia devolver solo los elementos que aparece una cantidad pares de veces", () => {
     expect(
       filtrarPares([1, 1, 2, 3, 4, 4, 5])
-    ).toBe([1, 4]);
+    ).toEqual([1, 4]);
   });
 });


### PR DESCRIPTION
toBe se utiliza para comparar valores primitivos y objetos literales. Para comparar arrays, deberia usarse toEqual en su lugar.