### PR TITLE
arreglo test para comprobar los valores del array

### DIFF
--- a/ejercicios-algoritmos/sesion-1/elementos-pares/index.test.ts
+++ b/ejercicios-algoritmos/sesion-1/elementos-pares/index.test.ts
@@ -4,8 +4,6 @@ import filtrarPares from ".";
 
 describe("filtrarPares", () => {
   it("deberia devolver solo los elementos que aparece una cantidad pares de veces", () => {
-    expect(
-      filtrarPares([1, 1, 2, 3, 4, 4, 5])
-    ).toBe([1, 4]);
+    expect(filtrarPares([1, 1, 2, 3, 4, 4, 5])).toEqual([1, 4]);
   });
 });


### PR DESCRIPTION
Buenas 👋,

Propongo cambiar el método para checkear si los arrays son iguales en el ejercicio “elementos-pares”. Según tengo entendido el método de vitest toBe es para la comparación de tipos primitivos o los valores de tipos no primitivos. Para comparar los valores internos de tipos de datos no primitivos, según la documentación, hay que utilizar toEqual.

Para hacer la prueba de lo que comento os dejo mi solución y el mensaje que me sale.
Solución:
```
export default function filtrarPares(array: unknown[]): unknown[] {
  array.sort();
  let matches = 0;
  const result = [] as unknown[];

  for (let i = 0; i < array.length - 1; i++) {
    const current = array[i];
    const next = array[i + 1];

    matches++;

    if (current !== next) {
      if (matches % 2 === 0) result.push(current);
      matches = 0;
    }
  }

  return result;
}
```

Mensaje que me devuelve:
```
AssertionError: expected [ 1, 4 ] to be [ 1, 4 ] // Object.is equality
```
Adjunto el link de la documentación donde comenta lo que digo.
https://vitest.dev/api/expect.html#tobe

Un saludo, muchas gracias