### PR TITLE
fix: corecciones para tipos, tests y readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ En este repositorio se iran subiendo algunos de los challenges que resolvemos en
 * [Ejercicios de algorítmos](./ejercicios-algoritmos/): Similares a los que toman en entrevistas de live-coding, tanto para posiciones frontend como backend.
     * [Sesión 1](./ejercicios-algoritmos/sesion-1/) - [STREAM](https://www.youtube.com/watch?v=W20aHH7F1q8)
     * [Sesión 2](./ejercicios-algoritmos/sesion-2/) - [STREAM](https://youtu.be/Mu9kdqCna90)
-    * [Sesión 3](./ejercicios-algoritmos/sesion-3/) - [STREAM](https://www.youtube.com/watch?v=EdqCkmJsmi4)
-    * [Sesión 4](./ejercicios-algoritmos/sesion-4/) - [STREAM](https://youtu.be/LW681EfHZFc)
+    * [Sesión 3](./ejercicios-algoritmos/sesion-3/) - [STREAM](https://youtu.be/LW681EfHZFc)
+    * [Sesión 4](./ejercicios-algoritmos/sesion-4/) - [STREAM](https://www.youtube.com/watch?v=EdqCkmJsmi4)
     * [Sesión 5](./ejercicios-algoritmos/sesion-5/) - [STREAM](https://youtu.be/dnQfXgGR06o)
 * [Proyectos live](./proyectos-live): Similares a los que toman en entrevistas técnicas para posiciones de front-end, donde hay que resolver errors o implementar nuevas funcionalidades.
     * [Búsqueda de productos](./proyectos-live/buscador-de-lista) - [STREAM](https://www.youtube.com/watch?v=SG5FFwLDuSQ)

--- a/ejercicios-algoritmos/sesion-1/elementos-pares/index.test.ts
+++ b/ejercicios-algoritmos/sesion-1/elementos-pares/index.test.ts
@@ -6,6 +6,6 @@ describe("filtrarPares", () => {
   it("deberia devolver solo los elementos que aparece una cantidad pares de veces", () => {
     expect(
       filtrarPares([1, 1, 2, 3, 4, 4, 5])
-    ).toBe([1, 4]);
+    ).toEqual([1, 4]);
   });
 });

--- a/ejercicios-algoritmos/sesion-1/isograma/index.test.ts
+++ b/ejercicios-algoritmos/sesion-1/isograma/index.test.ts
@@ -4,7 +4,7 @@ import esIsograma from ".";
 
 describe("esIsograma", () => {
   it("debería devolver true si es un isograma", () => {
-    expect(esIsograma("gato")).toBe(false);
+    expect(esIsograma("gato")).toBe(true);
   });
 
   it("debería ignorar acentos", () => {

--- a/ejercicios-algoritmos/sesion-1/transformador/index.test.ts
+++ b/ejercicios-algoritmos/sesion-1/transformador/index.test.ts
@@ -9,7 +9,7 @@ describe("transformer", () => {
         nombres: ["Juan", "Pedro", "María"],
         edades: [23, 45, 18],
       })
-    ).toBe([
+    ).toEqual([
       {
         id: 1,
         nombre: "Juan",

--- a/ejercicios-algoritmos/sesion-1/transformador/index.ts
+++ b/ejercicios-algoritmos/sesion-1/transformador/index.ts
@@ -4,9 +4,9 @@ type Input = {
 };
 
 type Output = {
-  id: string;
+  id: number;
   nombre: string;
-  edad: string;
+  edad: number;
 };
 
 export default function transformador(input: Input): Output[] {

--- a/ejercicios-algoritmos/sesion-2/palindromos/README.md
+++ b/ejercicios-algoritmos/sesion-2/palindromos/README.md
@@ -10,7 +10,7 @@ Ejemplo:
 54322345
 ```
 
-Escribir una función que verifique si un números puede ser reordenado para formar un palíndromo.
+Escribir una función que verifique si un número puede ser reordenado para formar un palíndromo.
 
 Nota: Los valores siempre serán numéricos y positivos.
 

--- a/ejercicios-algoritmos/sesion-2/palindromos/index.test.ts
+++ b/ejercicios-algoritmos/sesion-2/palindromos/index.test.ts
@@ -9,6 +9,7 @@ describe("posiblePalindromo", () => {
     expect(posiblePalindromo(1331)).toBe(true);
     expect(posiblePalindromo(3357665)).toBe(true);
     expect(posiblePalindromo(1221333)).toBe(true);
+    expect(posiblePalindromo(5)).toBe(true);
   });
 
   it("debería devolver false si no es un posible palindromo", () => {

--- a/ejercicios-algoritmos/sesion-4/encontrar-al-mas-viejo/index.ts
+++ b/ejercicios-algoritmos/sesion-4/encontrar-al-mas-viejo/index.ts
@@ -2,5 +2,5 @@ import type { Developer } from "./types";
 
 export default function encontrarAlMasViejo(developers: Developer[]): Developer[] {
   // TODO: implementar
-  return {};
+  return [];
 }

--- a/ejercicios-algoritmos/sesion-5/lis/README.md
+++ b/ejercicios-algoritmos/sesion-5/lis/README.md
@@ -2,7 +2,7 @@
 
 Se necesita implementar una función que recibe un array de enteros positivos cómo parámetro y tiene que devolver la secuencia incremental más larga (LIS: Longest increasing subsequence). Una LIS es un set de la lista original en dónde los números están ordenados, del más chico al más grande. La secuencia no tiene que ser contigua o única, y obviamente puede haber varias secuencias distintas.
 
-Por ejemplo: Si el array es `[4, 3, 5, 1, 6]` una posible LIS es `[3, 5, 6]` y otra es `[1, 6]`. Para este array, la función tiene que devolver `3` porque es el largo de la LIS más larga.
+Por ejemplo: Si el array es `[4, 3, 5, 1, 6]` una posible LIS es `[3, 5, 6]`, `[4, 5, 6]` y otra es `[1, 6]`. Para este array, la función tiene que devolver `3` porque es el largo de la LIS más larga.
 
 ```js
 [9, 9, 4, 2]  =>  1

--- a/ejercicios-algoritmos/sesion-5/urinales/index.test.ts
+++ b/ejercicios-algoritmos/sesion-5/urinales/index.test.ts
@@ -8,4 +8,5 @@ describe("urinalesLibres", () => {
   it("00000 => 3", () => expect(urinalesLibres("00000")).toBe(3));
   it("000 => 2", () => expect(urinalesLibres("000")).toBe(2));
   it("01000 => 1", () => expect(urinalesLibres("01000")).toBe(1));
+  it("011 => -1", () => expect(urinalesLibres("011")).toBe(-1));
 });


### PR DESCRIPTION
Hola

Agrego fixes de pr activos, menciones propias en los sesiones donde se resuelven y demás encontrados.

En los readme se arreglan detalles como palabras, links, y correciones de goncy en stream

En los index.ts se arreglan tipos que muestran warning sin haber realizado el ejercicio

En los index.test.ts se arreglan metodos incorrectos que marcan incorrectos soluciones cuando sí lo son. Además, más tests mencionados en los stream o en los readme del ejercicio correspondiente
