### PR TITLE
fix(isograma): fix incorrect test for "gato"

### DIFF
--- a/ejercicios-algoritmos/sesion-1/isograma/index.test.ts
+++ b/ejercicios-algoritmos/sesion-1/isograma/index.test.ts
@@ -4,7 +4,7 @@ import esIsograma from ".";
 
 describe("esIsograma", () => {
   it("debería devolver true si es un isograma", () => {
-    expect(esIsograma("gato")).toBe(false);
+    expect(esIsograma("gato")).toBe(true);
   });
 
   it("debería ignorar acentos", () => {


### PR DESCRIPTION
The test for the word "gato" was failing incorrectly. This update ensures that "gato" is correctly identified as an isogram.