### PR TITLE
Fix incorrect test and type in transformador

### DIFF
--- a/ejercicios-algoritmos/sesion-1/transformador/index.test.ts
+++ b/ejercicios-algoritmos/sesion-1/transformador/index.test.ts
@@ -9,7 +9,7 @@ describe("transformer", () => {
         nombres: ["Juan", "Pedro", "María"],
         edades: [23, 45, 18],
       })
-    ).toBe([
+    ).toEqual([
       {
         id: 1,
         nombre: "Juan",

--- a/ejercicios-algoritmos/sesion-1/transformador/index.ts
+++ b/ejercicios-algoritmos/sesion-1/transformador/index.ts
@@ -4,9 +4,9 @@ type Input = {
 };
 
 type Output = {
-  id: string;
+  id: number;
   nombre: string;
-  edad: string;
+  edad: number;
 };
 
 export default function transformador(input: Input): Output[] {


### PR DESCRIPTION
This PR fixes two issues in transformador

1. Incorrect test assertion – The test was using toBe, but since arrays are compared by reference, it should use toEqual.
2. Incorrect type definition – The Output type defined id and edad as string, but they should be number.

Both changes ensure correct behavior and proper type validation. 🚀