### PR TITLE
fix(transformador): fix id type in README.md

### DIFF
--- a/ejercicios-algoritmos/sesion-1/transformador/README.md
+++ b/ejercicios-algoritmos/sesion-1/transformador/README.md
@@ -23,7 +23,7 @@ Devuelve:
 
 ```js
 [
-  { id: "1", nombre: "Bruno", edad: 20 },
-  { id: "2", nombre: "Andrea", edad: 19 },
+  { id: 1, nombre: "Bruno", edad: 20 },
+  { id: 2, nombre: "Andrea", edad: 19 },
 ];
 ```


### PR DESCRIPTION
Fix README example to match the interface of Output

type Output = {
  id: number;
  nombre: string;
  edad: number;
};