### PR TITLE
Add test case for repeated letters handling in anagrams

### DIFF
--- a/ejercicios-algoritmos/sesion-7/anagramas/README.md
+++ b/ejercicios-algoritmos/sesion-7/anagramas/README.md
@@ -8,4 +8,5 @@ sonAnagramas("elbow", "below"); // true
 sonAnagramas("study", "dusty"); // true
 sonAnagramas("hello", "world"); // false
 sonAnagramas("A gentleman", "Elegant man"); // true
+sonAnagramas("food", "doff"); // false
 ```

--- a/ejercicios-algoritmos/sesion-7/anagramas/index.test.ts
+++ b/ejercicios-algoritmos/sesion-7/anagramas/index.test.ts
@@ -17,4 +17,7 @@ describe("sonAnagramas", () => {
   
   it("maneja strings vacíos", () =>
     expect(sonAnagramas("", "")).toBe(true));
+    
+  it("maneja letras repetidas", () =>
+    expect(sonAnagramas("food", "doff")).toBe(false));
 });


### PR DESCRIPTION
sesion-7/anagramas

Adds a new test case to the sonAnagramas test suite to ensure the algorithm correctly handles words with repeated letters.
The new case checks that words containing the same letters in different repetition counts are not considered anagrams.

* This test prevents false positives in implementations that ignore repeated letters (for example, those using Set)

Expected result:
The test should only pass if the algorithm correctly distinguishes between:

"food" → contains two o
"doff" → contains two f

Expected output: false